### PR TITLE
Cast id columns to string

### DIFF
--- a/src/validation_pipeline.ipynb
+++ b/src/validation_pipeline.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "90c94976-cf1a-4e03-b98d-ea0785e495ee",
    "metadata": {},
    "outputs": [],
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "fb77baac-2822-49f3-90d2-fc567669cb28",
    "metadata": {},
    "outputs": [],
@@ -57,54 +57,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "8445bf48-8cbe-4a22-83e5-085bed7f2bd0",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'metadata_keys': ['type', 'format', 'values'],\n",
-       " 'hosts': {'host_id': {'type': 'string', 'format': 'AA0_00000'},\n",
-       "  'host_groupNumber': {'type': 'integer'},\n",
-       "  'host_sex': {'type': 'string', 'format': 'A', 'values': ['M', 'F']},\n",
-       "  'host_age': {'type': 'integer'},\n",
-       "  'host_death': {'type': 'integer'},\n",
-       "  'host_species': {'type': 'string'},\n",
-       "  'host_breed': {'type': 'string'}},\n",
-       " 'events': {'host_id': {'type': 'string', 'format': 'AA0_00000'},\n",
-       "  'event_day': {'type': 'integer'},\n",
-       "  'event_time': {'type': 'string', 'format': 'HH:MM'},\n",
-       "  'event_type': {'type': 'string',\n",
-       "   'values': ['measurement', 'inoculation', 'treatment']},\n",
-       "  'measurement_type': {'type': 'string'},\n",
-       "  'measurement_quantity': {'type': 'float'},\n",
-       "  'measurement_unit': {'type': 'string'},\n",
-       "  'inoculation_type': {'type': 'string'},\n",
-       "  'inoculation_pathogen': {'type': 'string'},\n",
-       "  'inoculation_dose': {'type': 'float'},\n",
-       "  'inoculation_unit': {'type': 'string'},\n",
-       "  'treatment_type': {'type': 'string'},\n",
-       "  'treatment_dose': {'type': 'float'},\n",
-       "  'treatment_unit': {'type': 'string'}},\n",
-       " 'environment': {'environment_level': {'type': 'integer',\n",
-       "   'values': ['1', '2', '3']},\n",
-       "  'environment_id': {'type': 'string', 'format': 'A0_A0'}},\n",
-       " 'environment_events': {'host_id': {'type': 'string', 'format': 'AA0_00000'},\n",
-       "  'environment_id': {'type': 'string', 'format': 'A0_A0'},\n",
-       "  'event_type': {'type': 'string', 'values': ['measurement', 'allocation']},\n",
-       "  'event_day': {'type': 'integer'},\n",
-       "  'event_time': {'type': 'string', 'format': 'HH:MM'},\n",
-       "  'measurement_type': {'type': 'string'},\n",
-       "  'measurement_quantity': {'type': 'float'},\n",
-       "  'measurement_unit': {'type': 'string'}}}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "validation = toml.load(validation_path)\n",
     "validation"
@@ -146,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "a00ed1f5-061d-4732-b85e-830e7fc46899",
    "metadata": {},
    "outputs": [],
@@ -165,18 +121,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "722e7a3c-2887-415d-9694-5837827ce333",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Found files: ['environment_events.csv', 'environment.csv', 'host_events.csv', 'hosts.csv']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "files = [f.name for f in proj_data_path.glob('**/*.csv') if f.is_file()]\n",
     "files = [f for f in files if f in ['environment_events.csv', 'environment.csv', 'host_events.csv', 'hosts.csv']]\n",
@@ -197,18 +145,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "9fe43c78-6ff0-4d6d-8a99-11de63258e33",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "dict_keys(['environment_events.csv', 'environment.csv', 'host_events.csv', 'hosts.csv'])\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = {}\n",
     "for f in files:\n",
@@ -230,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "b43a63e2-d055-464d-bed3-10ccc0f7404a",
    "metadata": {},
    "outputs": [],
@@ -256,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a459263c-9d5b-4dc6-9ec8-f50ef7438f3e",
    "metadata": {},
    "outputs": [],
@@ -274,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "4d7557a3-55b0-4b3e-b7f5-6ee7a0c984fb",
    "metadata": {},
    "outputs": [],
@@ -294,44 +234,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "ef9e2645-ad0e-4ff3-a851-6c792c4b5c4b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "----\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "check_column_exists(data, validation)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "e3ae9335-d544-4f36-96a2-c4f9f6b8bbde",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Checking environment_events.csv against environment_events:\n",
-      "Checking environment.csv against environment:\n",
-      "Checking host_events.csv against events:\n",
-      "event_day should be integer\n",
-      "\t Found: float64\n",
-      "treatment_unit should be string\n",
-      "\t Found: float64\n",
-      "Checking hosts.csv against hosts:\n",
-      "----\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "check_column_types(data, validation)"
    ]
@@ -354,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "42943b13-4b2f-4dc3-9065-fad287532098",
    "metadata": {},
    "outputs": [],
@@ -369,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "9d32e6a3-d588-4809-9330-bd811fc6cc44",
    "metadata": {},
    "outputs": [],
@@ -390,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "b56b73a4-63e4-43dc-a744-c4c9cbc31b4e",
    "metadata": {},
    "outputs": [],
@@ -401,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "f6df6a71-138c-461a-aead-8c2fd5a0c6b2",
    "metadata": {},
    "outputs": [],
@@ -420,23 +336,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "feff4836-6a0f-4b17-93bb-fc7fbbca9c4f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File environment_events.csv contains undefined ids in column host_id:\n",
-      "{'iM3', 'qE1', 'lJ8', 'eB9', 'sG1', 'oI4', 'eA2', 'gC7', 'rA3', 'dX7', 'fB3', 'wL3', 'sA5', 'xW8', 'cZ3', 'jF8', 'bE4', 'lP5', 'yF4', 'qM7', 'gA8', 'cM9', 'xL4', 'bH2', 'bX7', 'iR5', 'oL5', 'uF5', 'dZ8', 'cV6', 'eB2', 'sQ9', 'xH7', 'hW5', 'yN7', 'uP4', 'bI0', 'hH9', 'hC2', 'gI4', 'uA1', 'xD2', 'hD8', 'tN6', 'iZ9', 'tB5', 'wX3', 'hE4', 'aF1', 'mF9', 'rD6', 'eQ0', 'oU1', 'gD1', 'cF6', 'vF9', 'dJ8', 'tB2', 'oO2', 'yZ5', 'eK8', 'iG2', 'vK3', 'kB0', 'xG1', 'gT8', 'uP0', 'bE5', 'mH1', 'iW1', 'gZ4', 'cP1', 'xK5', 'oN2', 'fA7', 'iW3', 'nQ8', 'yL4', 'uQ5', 'oJ0', 'zV9', 'mN5', 'wF0', 'pR0', 'hG4', 'lD2', 'vH4', 'pX3', 'gM8', 'uA2', 'zT4', 'xP9', 'eQ5', 'qX3', 'vF8', 'aI5', 'bU5', 'lI2', 'dB4', 'mU8'}\n",
-      "File host_events.csv contains undefined ids in column host_id:\n",
-      "{'sU0', 'jX6', 'oV2', 'aY5', 'mM3', 'kO5', 'pN2', 'oH0', 'lF5', 'cP4', 'bX6', 'dH2', 'lD9', 'uL0', 'xZ7', 'aH4', 'qD9', 'vP8', 'eZ7', 'yO8', 'aF9', 'bL5', 'aY6', 'jQ9', 'tN4', 'jW6', 'sW8', 'rS9', 'hY5', 'fX2', 'xK2', 'bK0', 'wM3', 'lI1', 'gF1', 'yN5', 'zF3', 'kC8', 'pS7', 'rN2', 'oP4', 'hV6', 'vU8', 'sI0', 'zD5', 'zS6', 'gU0', 'vF4', 'dT0', 'wZ5', 'oX3', 'cU5', 'pO9', 'lB6', 'hH8', 'oN5', 'gV9', 'yJ0', 'tX6', 'gM3', 'vT4', 'qG5', 'hQ7', 'rJ0', 'hF1', 'vJ8', 'bH3', 'uG3', 'zM4', 'aT9', 'wP3', 'wR7', 'wF9', 'oW5', 'kK6', 'sG0', 'iU8', 'fO0', 'xI4', 'aD7', 'nH2', 'cN7', 'sK2', 'rQ2', 'hP7', 'nL2', 'lC2', 'sP4', 'iF0', 'rS8', 'yO2', 'nD1', 'iJ1', 'wM5', 'iF3', 'xX8', 'mP5', 'lI7', 'yF0', 'qU7'}\n",
-      "File environment_events.csv contains undefined ids in column environment_id:\n",
-      "{'pG3', 'vH1', 'lR8', 'yO5', 'lF5', 'jY3', 'qI0', 'pV1', 'kJ6', 'eZ5', 'sT7', 'fM1', 'zB1', 'qK7', 'jM7', 'lI3', 'cY5', 'eE7', 'lS9', 'oB6', 'oX9', 'qX8', 'rD7', 'jN1', 'jJ4', 'xS2', 'hA7', 'cA8', 'rM5', 'nQ2', 'uI4', 'lG6', 'kH6', 'yH0', 'dJ1', 'yH4', 'sW4', 'zF3', 'pH3', 'qJ1', 'gI4', 'bU2', 'xP3', 'vF6', 'pW1', 'fT5', 'zG7', 'hM9', 'cW1', 'lL8', 'gS7', 'cJ4', 'rO1', 'cM2', 'hV2', 'jZ6', 'rI6', 'wM2', 'bK4', 'xL7', 'sB2', 'yJ0', 'fV7', 'aX8', 'xV9', 'eA1', 'yL9', 'oI2', 'lZ3', 'dW2', 'sP7', 'rN7', 'uG1', 'kW2', 'aM1', 'sG7', 'lW2', 'aE0', 'qI2', 'jL8', 'pR8', 'iP7', 'mH5', 'wD4', 'iN6', 'vD2', 'bY4', 'cB4', 'lK1', 'cW0', 'rA0', 'iT6', 'pD6', 'kG2', 'vU6', 'dQ9', 'nK7'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for id_type in ids:\n",
     "    for data_name in data:\n",

--- a/src/validation_pipeline.ipynb
+++ b/src/validation_pipeline.ipynb
@@ -2,13 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "90c94976-cf1a-4e03-b98d-ea0785e495ee",
    "metadata": {},
    "outputs": [],
    "source": [
     "import toml\n",
     "import pandas as pd\n",
+    "\n",
     "from pathlib import Path"
    ]
   },
@@ -38,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "fb77baac-2822-49f3-90d2-fc567669cb28",
    "metadata": {},
    "outputs": [],
@@ -56,10 +57,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "8445bf48-8cbe-4a22-83e5-085bed7f2bd0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'metadata_keys': ['type', 'format', 'values'],\n",
+       " 'hosts': {'host_id': {'type': 'string', 'format': 'AA0_00000'},\n",
+       "  'host_groupNumber': {'type': 'integer'},\n",
+       "  'host_sex': {'type': 'string', 'format': 'A', 'values': ['M', 'F']},\n",
+       "  'host_age': {'type': 'integer'},\n",
+       "  'host_death': {'type': 'integer'},\n",
+       "  'host_species': {'type': 'string'},\n",
+       "  'host_breed': {'type': 'string'}},\n",
+       " 'events': {'host_id': {'type': 'string', 'format': 'AA0_00000'},\n",
+       "  'event_day': {'type': 'integer'},\n",
+       "  'event_time': {'type': 'string', 'format': 'HH:MM'},\n",
+       "  'event_type': {'type': 'string',\n",
+       "   'values': ['measurement', 'inoculation', 'treatment']},\n",
+       "  'measurement_type': {'type': 'string'},\n",
+       "  'measurement_quantity': {'type': 'float'},\n",
+       "  'measurement_unit': {'type': 'string'},\n",
+       "  'inoculation_type': {'type': 'string'},\n",
+       "  'inoculation_pathogen': {'type': 'string'},\n",
+       "  'inoculation_dose': {'type': 'float'},\n",
+       "  'inoculation_unit': {'type': 'string'},\n",
+       "  'treatment_type': {'type': 'string'},\n",
+       "  'treatment_dose': {'type': 'float'},\n",
+       "  'treatment_unit': {'type': 'string'}},\n",
+       " 'environment': {'environment_level': {'type': 'integer',\n",
+       "   'values': ['1', '2', '3']},\n",
+       "  'environment_id': {'type': 'string', 'format': 'A0_A0'}},\n",
+       " 'environment_events': {'host_id': {'type': 'string', 'format': 'AA0_00000'},\n",
+       "  'environment_id': {'type': 'string', 'format': 'A0_A0'},\n",
+       "  'event_type': {'type': 'string', 'values': ['measurement', 'allocation']},\n",
+       "  'event_day': {'type': 'integer'},\n",
+       "  'event_time': {'type': 'string', 'format': 'HH:MM'},\n",
+       "  'measurement_type': {'type': 'string'},\n",
+       "  'measurement_quantity': {'type': 'float'},\n",
+       "  'measurement_unit': {'type': 'string'}}}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "validation = toml.load(validation_path)\n",
     "validation"
@@ -101,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "a00ed1f5-061d-4732-b85e-830e7fc46899",
    "metadata": {},
    "outputs": [],
@@ -120,10 +165,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "722e7a3c-2887-415d-9694-5837827ce333",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found files: ['environment_events.csv', 'environment.csv', 'host_events.csv', 'hosts.csv']\n"
+     ]
+    }
+   ],
    "source": [
     "files = [f.name for f in proj_data_path.glob('**/*.csv') if f.is_file()]\n",
     "files = [f for f in files if f in ['environment_events.csv', 'environment.csv', 'host_events.csv', 'hosts.csv']]\n",
@@ -144,10 +197,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "9fe43c78-6ff0-4d6d-8a99-11de63258e33",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['environment_events.csv', 'environment.csv', 'host_events.csv', 'hosts.csv'])\n"
+     ]
+    }
+   ],
    "source": [
     "data = {}\n",
     "for f in files:\n",
@@ -168,6 +229,62 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b43a63e2-d055-464d-bed3-10ccc0f7404a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from validation_utils import *"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0163cd4-4b64-4fec-89c1-658220c616df",
+   "metadata": {},
+   "source": [
+    "### If identifier columns are not of type string, cast to string."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "804f95ff-7544-4318-8bb2-38efdff55b32",
+   "metadata": {},
+   "source": [
+    "*Parameters*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a459263c-9d5b-4dc6-9ec8-f50ef7438f3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_col_names = [\"host_id\", \"environment_id\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c5a2f7e-cedc-490b-b963-a0c4ab6a4c28",
+   "metadata": {},
+   "source": [
+    "*Code*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4d7557a3-55b0-4b3e-b7f5-6ee7a0c984fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for data_name in data:\n",
+    "    for col_name in id_col_names:\n",
+    "        cast_col_to_string(data[data_name], col_name)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "d848836d-4628-4796-ab85-d2e6be8b1dcf",
    "metadata": {},
@@ -177,30 +294,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b43a63e2-d055-464d-bed3-10ccc0f7404a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from validation_utils import *"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "ef9e2645-ad0e-4ff3-a851-6c792c4b5c4b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "----\n"
+     ]
+    }
+   ],
    "source": [
     "check_column_exists(data, validation)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "e3ae9335-d544-4f36-96a2-c4f9f6b8bbde",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking environment_events.csv against environment_events:\n",
+      "Checking environment.csv against environment:\n",
+      "Checking host_events.csv against events:\n",
+      "event_day should be integer\n",
+      "\t Found: float64\n",
+      "treatment_unit should be string\n",
+      "\t Found: float64\n",
+      "Checking hosts.csv against hosts:\n",
+      "----\n"
+     ]
+    }
+   ],
    "source": [
     "check_column_types(data, validation)"
    ]
@@ -223,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "42943b13-4b2f-4dc3-9065-fad287532098",
    "metadata": {},
    "outputs": [],
@@ -238,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "9d32e6a3-d588-4809-9330-bd811fc6cc44",
    "metadata": {},
    "outputs": [],
@@ -259,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "b56b73a4-63e4-43dc-a744-c4c9cbc31b4e",
    "metadata": {},
    "outputs": [],
@@ -270,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "f6df6a71-138c-461a-aead-8c2fd5a0c6b2",
    "metadata": {},
    "outputs": [],
@@ -289,10 +420,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "feff4836-6a0f-4b17-93bb-fc7fbbca9c4f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File environment_events.csv contains undefined ids in column host_id:\n",
+      "{'iM3', 'qE1', 'lJ8', 'eB9', 'sG1', 'oI4', 'eA2', 'gC7', 'rA3', 'dX7', 'fB3', 'wL3', 'sA5', 'xW8', 'cZ3', 'jF8', 'bE4', 'lP5', 'yF4', 'qM7', 'gA8', 'cM9', 'xL4', 'bH2', 'bX7', 'iR5', 'oL5', 'uF5', 'dZ8', 'cV6', 'eB2', 'sQ9', 'xH7', 'hW5', 'yN7', 'uP4', 'bI0', 'hH9', 'hC2', 'gI4', 'uA1', 'xD2', 'hD8', 'tN6', 'iZ9', 'tB5', 'wX3', 'hE4', 'aF1', 'mF9', 'rD6', 'eQ0', 'oU1', 'gD1', 'cF6', 'vF9', 'dJ8', 'tB2', 'oO2', 'yZ5', 'eK8', 'iG2', 'vK3', 'kB0', 'xG1', 'gT8', 'uP0', 'bE5', 'mH1', 'iW1', 'gZ4', 'cP1', 'xK5', 'oN2', 'fA7', 'iW3', 'nQ8', 'yL4', 'uQ5', 'oJ0', 'zV9', 'mN5', 'wF0', 'pR0', 'hG4', 'lD2', 'vH4', 'pX3', 'gM8', 'uA2', 'zT4', 'xP9', 'eQ5', 'qX3', 'vF8', 'aI5', 'bU5', 'lI2', 'dB4', 'mU8'}\n",
+      "File host_events.csv contains undefined ids in column host_id:\n",
+      "{'sU0', 'jX6', 'oV2', 'aY5', 'mM3', 'kO5', 'pN2', 'oH0', 'lF5', 'cP4', 'bX6', 'dH2', 'lD9', 'uL0', 'xZ7', 'aH4', 'qD9', 'vP8', 'eZ7', 'yO8', 'aF9', 'bL5', 'aY6', 'jQ9', 'tN4', 'jW6', 'sW8', 'rS9', 'hY5', 'fX2', 'xK2', 'bK0', 'wM3', 'lI1', 'gF1', 'yN5', 'zF3', 'kC8', 'pS7', 'rN2', 'oP4', 'hV6', 'vU8', 'sI0', 'zD5', 'zS6', 'gU0', 'vF4', 'dT0', 'wZ5', 'oX3', 'cU5', 'pO9', 'lB6', 'hH8', 'oN5', 'gV9', 'yJ0', 'tX6', 'gM3', 'vT4', 'qG5', 'hQ7', 'rJ0', 'hF1', 'vJ8', 'bH3', 'uG3', 'zM4', 'aT9', 'wP3', 'wR7', 'wF9', 'oW5', 'kK6', 'sG0', 'iU8', 'fO0', 'xI4', 'aD7', 'nH2', 'cN7', 'sK2', 'rQ2', 'hP7', 'nL2', 'lC2', 'sP4', 'iF0', 'rS8', 'yO2', 'nD1', 'iJ1', 'wM5', 'iF3', 'xX8', 'mP5', 'lI7', 'yF0', 'qU7'}\n",
+      "File environment_events.csv contains undefined ids in column environment_id:\n",
+      "{'pG3', 'vH1', 'lR8', 'yO5', 'lF5', 'jY3', 'qI0', 'pV1', 'kJ6', 'eZ5', 'sT7', 'fM1', 'zB1', 'qK7', 'jM7', 'lI3', 'cY5', 'eE7', 'lS9', 'oB6', 'oX9', 'qX8', 'rD7', 'jN1', 'jJ4', 'xS2', 'hA7', 'cA8', 'rM5', 'nQ2', 'uI4', 'lG6', 'kH6', 'yH0', 'dJ1', 'yH4', 'sW4', 'zF3', 'pH3', 'qJ1', 'gI4', 'bU2', 'xP3', 'vF6', 'pW1', 'fT5', 'zG7', 'hM9', 'cW1', 'lL8', 'gS7', 'cJ4', 'rO1', 'cM2', 'hV2', 'jZ6', 'rI6', 'wM2', 'bK4', 'xL7', 'sB2', 'yJ0', 'fV7', 'aX8', 'xV9', 'eA1', 'yL9', 'oI2', 'lZ3', 'dW2', 'sP7', 'rN7', 'uG1', 'kW2', 'aM1', 'sG7', 'lW2', 'aE0', 'qI2', 'jL8', 'pR8', 'iP7', 'mH5', 'wD4', 'iN6', 'vD2', 'bY4', 'cB4', 'lK1', 'cW0', 'rA0', 'iT6', 'pD6', 'kG2', 'vU6', 'dQ9', 'nK7'}\n"
+     ]
+    }
+   ],
    "source": [
     "for id_type in ids:\n",
     "    for data_name in data:\n",
@@ -383,9 +527,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d92517e6-0a8e-4198-a6cb-62e2dc3da230",
+   "metadata": {},
+   "source": [
+    "## Converting columns"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ba01ad6-5dbe-4a28-9765-98b47a837046",
+   "id": "4ac11422-45c0-44cb-8713-2bc96ae98966",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c8e383c-2a88-424b-9e15-725b361e51d9",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -407,7 +567,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/src/validation_utils.py
+++ b/src/validation_utils.py
@@ -28,6 +28,11 @@ def check_column_types(data, validation):
                     print(f"\t Found: {str(data[data_name][var_name].dtype)}")
     print("----")
 
+def cast_col_to_string(df, col_name):
+    """Cast the type of the column to string (object)."""
+    if col_name in df.columns:
+        df[col_name] = df[col_name].astype(str)
+
 def check_column_exists(data, validation):
     """Iterate over all csv files and check if all columns are present."""
     for data_name in data:


### PR DESCRIPTION
In the workflow we make sure that the identifier columns are cast to string before executing the checks.
I added 
- a function, taking a dataframe and a column name which casts the column to string
- Extended the workflow in the testing section of the jupyter notebook.